### PR TITLE
Rename metavariables and improve documentation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cond"
 version = "1.0.3"
-authors = ["CheckM4te", "github.com/Esper89"]
+authors = ["CheckM4te"]
 license = "MIT"
 description = "Rust macro to use a match-like syntax as an elegant alternative to nesting if-else statements"
 homepage = "https://github.com/checkm4ted/cond"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-# cond
-Rust macro to use a match-like syntax as a elegant alternative to nesting if-else statement.  
-I got the idea from Go's empty switch statements. I thought it could be cool if it was in rust so I asked if that was possible in rust's discord server. They told me it wasn't unless you used a pretty ugly syntax in a match, and Esper89 (github in credits) made a macro for it. I added some tests and documentation and here's my first rust crate. 
+# `cond`
 
-# example:
-```rust
+Rust macro to use a match-like syntax as an elegant alternative to many `if`-`else` statements.
+
+I got the idea from empty [Go `switch` statements](https://go.dev/ref/spec#Switch_statements). I thought it could be cool if it was in Rust so I asked if that was possible in the Rust community Discord server. They told me it wasn't unless you used a pretty ugly syntax in a match, and Esper89 (GitHub in credits) made a macro for it. I added some tests and documentation and here's my first Rust crate.
+
+## Example
+
+```rs
 use cond::cond;
 
 fn main() {
@@ -28,16 +31,19 @@ fn main() {
 
     println!("result: {}", result);
 }
-
 ```
 
-# usage
-You can just add the crate with
-```bash
+## Usage
+
+You can just add the crate with:
+
+```sh
 cargo add cond
 ```
-Or just add the 4 line macro in your project:
-```rust
+
+Or just add the 8 line macro to your project:
+
+```rs
 macro_rules! cond {
     ($($condition:expr => $value:expr),* $(, _ => $default:expr)? $(,)?) => {
         match () {
@@ -48,5 +54,6 @@ macro_rules! cond {
 }
 ```
 
-# credits
-Credits to github.com/Esper89 for essentially making the whole macro in the Rust discord server.
+## Credits
+
+Credits to [Esper89](https://github.com/Esper89) for essentially making the whole macro in the Rust community Discord server.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ cargo add cond
 Or just add the 4 line macro in your project:
 ```rust
 macro_rules! cond {
-    ($($cond:expr => $value:expr),* $(, _ => $dft:expr)? $(,)?) => {
+    ($($condition:expr => $value:expr),* $(, _ => $default:expr)? $(,)?) => {
         match () {
-            $(() if $cond => $value,)*
-            () => ($($dft)?),
+            $(() if $condition => $value,)*
+            () => ($($default)?),
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@
 /// }
 /// ```
 macro_rules! cond {
-    ($($cond:expr => $value:expr),* $(, _ => $dft:expr)? $(,)?) => {
+    ($($condition:expr => $value:expr),* $(, _ => $default:expr)? $(,)?) => {
         match () {
-            $(() if $cond => $value,)*
-            () => ($($dft)?),
+            $(() if $condition => $value,)*
+            () => ($($default)?),
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
 #[macro_export]
 /// This is a macro to use a match with boolean conditions, like a empty switch in Go.
-/// 
-/// ```rust
+///
+/// ```
+/// # use cond::cond;
+/// # let a = 4;
 /// cond! {
 ///     a < 5 => println!("a is less than 5"),
-///}
+/// }
+/// ```
 macro_rules! cond {
     ($($cond:expr => $value:expr),* $(, _ => $dft:expr)? $(,)?) => {
         match () {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,74 @@
+//! A macro for matching on boolean conditions.
+//!
+//! For the full documentation, see [`cond`].
+
 #[macro_export]
-/// This is a macro to use a match with boolean conditions, like a empty switch in Go.
+/// A macro for matching on boolean conditions, like an empty [Go `switch` statement].
+///
+/// If the branches evalutate to `()`, you don't need a default branch.
 ///
 /// ```
 /// # use cond::cond;
-/// # let a = 4;
+/// let a = 4;
+/// let b = 5;
 /// cond! {
-///     a < 5 => println!("a is less than 5"),
+///     a < b => println!("a is less than b"),
+///     a > b => println!("a is greater than b"),
 /// }
 /// ```
+///
+/// If the branches evalute to any type other than `()`, you must include a default branch. The
+/// default branch uses `_` instead of a condition and must come last.
+///
+/// ```
+/// # use cond::cond;
+/// let a = 4;
+/// let b = 5;
+/// let text = cond! {
+///     a < b => "a is less than b",
+///     a > b => "a is greater than b",
+///     _ => "a is equal to b",
+/// };
+/// assert_eq!(text, "a is less than b");
+/// ```
+///
+/// # Caveat
+///
+/// Expressions that end with blocks must still have commas after them in `cond` invocations, unlike
+/// in `match` blocks.
+///
+/// The following `match` block does not need commas after each of its arms:
+///
+/// ```
+/// let x = 5;
+/// match x {
+///     ..=4 => {
+///         println!("x is 4 or less");
+///     }
+///     // No comma needed!
+///     5.. => {
+///         println!("x is 5 or greater");
+///     }
+/// }
+/// ```
+///
+/// But the equivalent `cond` invocation fails to compile:
+///
+/// ```compile_fail
+/// # use cond::cond;
+/// let x = 5;
+/// cond! {
+///     x <= 4 => {
+///         println!("x is 4 or less");
+///     }
+///     // Comma needed here!
+///     x >= 5 => {
+///         println!("x is 5 or greater");
+///     }
+/// }
+/// ```
+///
+/// [Go `switch` statement]: <https://go.dev/ref/spec#Switch_statements>
 macro_rules! cond {
     ($($condition:expr => $value:expr),* $(, _ => $default:expr)? $(,)?) => {
         match () {


### PR DESCRIPTION
Renames the `$cond` and `$dft` metavariables to `$condition` and `$default`, for clarity. Also improves documentation, fixes the broken doc test, and fixes a couple grammar and markdown mistakes in `README`.