### PR TITLE
Disable tests in `no_std` environments.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! For the full documentation, see [`cond`].
 
+//! Disable tests in `no_std` environments.
+#![cfg_attr(not(test), no_std)]
+
 #[macro_export]
 /// A macro for matching on boolean conditions, like an empty [Go `switch` statement].
 ///


### PR DESCRIPTION
Currently, `cond` has a dependency on `std` due to the tests. This makes it impossible to use `cond` in `no_std` environments.

This PR introduces a small change that makes `cond` `no_std` compatible when the tests are not used.