### PR TITLE
doc: sync README usage with last changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ Or just add the 8 line macro to your project:
 ```rs
 macro_rules! cond {
     ($($condition:expr => $value:expr),* $(, _ => $default:expr)? $(,)?) => {
-        match () {
-            $(() if $condition => $value,)*
-            () => ($($default)?),
-        }
+        $(if $condition { $value } else)*
+        { $($default)? }
     };
 }
 ```


### PR DESCRIPTION
Updates the usage section from the README to fit the last version of the macro.

See #3.